### PR TITLE
Add automated dev setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+ports:
+  - port: 4200
+    onOpen: open-preview
+tasks:
+  - before: echo N | npm install -g @angular/cli
+    init: for DIR in `ls -1` ; do cd $DIR && npm install && cd .. ; done
+    command: cd "${DIR:-v6-hello-world}" && ng serve

--- a/binding-demo/README.md
+++ b/binding-demo/README.md
@@ -2,6 +2,8 @@
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.5.3.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#DIR=binding-demo/https://github.com/gopinav/Angular-Tutorials/blob/master/binding-demo/README.md)
+
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.

--- a/components-misc/README.md
+++ b/components-misc/README.md
@@ -2,6 +2,8 @@
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.5.3.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#DIR=components-misc/https://github.com/gopinav/Angular-Tutorials/blob/master/components-misc/README.md)
+
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.

--- a/routing-demo/README.md
+++ b/routing-demo/README.md
@@ -2,6 +2,8 @@
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.5.3.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#DIR=routing-demo/https://github.com/gopinav/Angular-Tutorials/blob/master/routing-demo/README.md)
+
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.

--- a/services-and-http/README.md
+++ b/services-and-http/README.md
@@ -2,6 +2,8 @@
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.5.3.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#DIR=services-and-http/https://github.com/gopinav/Angular-Tutorials/blob/master/services-and-http/README.md)
+
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.

--- a/structural-directives/README.md
+++ b/structural-directives/README.md
@@ -2,6 +2,8 @@
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.5.3.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#DIR=structural-directives/https://github.com/gopinav/Angular-Tutorials/blob/master/structural-directives/README.md)
+
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.

--- a/v6-hello-world/README.md
+++ b/v6-hello-world/README.md
@@ -2,6 +2,8 @@
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 6.0.0.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#DIR=v6-hello-world/https://github.com/gopinav/Angular-Tutorials/blob/master/v6-hello-world/README.md)
+
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.

--- a/v6-services-and-http/README.md
+++ b/v6-services-and-http/README.md
@@ -2,6 +2,8 @@
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.5.3.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#DIR=v6-services-and-http/https://github.com/gopinav/Angular-Tutorials/blob/master/v6-services-and-http/README.md)
+
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.


### PR DESCRIPTION
Hi @gopinav 👋

Thanks a lot for the great video tutorials! I wish I had access to such great resources when I was learning web development. 💯

In this example PR, I've automated the dev setup of your Angular Tutorials, so that anyone can run them in one click. I've configured Gitpod to pre-install the `ng` CLI and all `npm` dependencies, and then to run `ng serve` in the requested directory.

Here is what it looks like:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#DIR=v6-hello-world/https://github.com/jankeromnes/Angular-Tutorials/blob/master/v6-hello-world/README.md)

![Screenshot 2019-06-11 at 14 04 17](https://user-images.githubusercontent.com/599268/59270601-28ba0f80-8c52-11e9-920c-5b4313327226.png)

Please let me know what you think.